### PR TITLE
Now supporting Paperclip 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Regardless of the width, the preview box and the cropping area will have the asp
 
 If you're rendering it on ajax ensure to call init_papercrop() in js after loading the crop form to make things work properly.  
 
+### Running the Tests
+
+We are using a dummy application to handle some of our test cases. You can find this in the `/test_app` directory and should be able to run this as a regular Rails 4 app _(using the `rails s` command)_ if you're interested in taking a look. You may need to create the mock database for the `test_app` before your tests will start to pass. This means you need to run `rake db:create db:migrate db:test:prepare` from within the `test_app` directory.
+
+In order to fully test our gem, we needed to use [Selenium](http://docs.seleniumhq.org/download/). Getting this setup is beyond the scope of this Readme.
+
+Once you have everything setup, you should be able `bundle exec rake` from the root directory have everything run. If you've installed Selenium properly, you should see an automated instance of your browser _(eg. Firefox)_ pop up and run through some of the integration tests.
+
 That's all!
 
 ### Credits and resources

--- a/papercrop.gemspec
+++ b/papercrop.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sass"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "database_cleaner"
+  s.add_development_dependency "selenium-webdriver"
 end

--- a/spec/integration/papercrop_js_spec.rb
+++ b/spec/integration/papercrop_js_spec.rb
@@ -19,7 +19,7 @@ describe "Image crop with JS", :js => true do
     click_button "Crop image"
 
     sleep 1
-    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).should eq(0.0)
+    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).round(2).should eq(0.0)
   end
 
 
@@ -45,6 +45,6 @@ describe "Image crop with JS", :js => true do
     click_button "Crop image"
 
     sleep 1
-    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).should eq(0.0)
+    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).round(2).should eq(0.0)
   end
 end

--- a/spec/integration/papercrop_spec.rb
+++ b/spec/integration/papercrop_spec.rb
@@ -29,6 +29,6 @@ describe "Image crop" do
 
     click_button "Crop image"
     
-    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).should eq(0.0)
+    compare_images(CROPPED_IMG_PATH, Landscape.last.picture.path(:medium)).round(2).should eq(0.0)
   end
 end

--- a/spec/model_extensions/model_extension_spec.rb
+++ b/spec/model_extensions/model_extension_spec.rb
@@ -29,8 +29,8 @@ describe "Model Extension" do
     @landscape.picture_crop_w = 400
     @landscape.picture_crop_h = 300
     @landscape.save
-
-    compare_images(CROPPED_IMG_PATH, @landscape.picture.path(:medium)).should eq(0.0)
+    # Rounding to account for different versions of imagemagick
+    compare_images(CROPPED_IMG_PATH, @landscape.picture.path(:medium)).round(2).should eq(0.0)
   end
 
 
@@ -60,12 +60,7 @@ describe "Model Extension" do
 
 
   it "registers the post processor" do
-    definitions = if @landscape.respond_to?(:attachment_definitions)
-      @landscape.attachment_definitions
-    else
-      Paperclip::Tasks::Attachments.instance.definitions_for(Landscape)
-    end
-
+    definitions = Paperclip::AttachmentRegistry.definitions_for(Landscape)
     definitions[:picture][:processors].should eq([:cropper])
   end
 

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.8'
+gem 'rails', '~> 4.0.0'
 
 gem 'jquery-rails'
 gem 'execjs'
 gem 'therubyracer'
 gem 'sqlite3'
-gem 'paperclip', '3.4.0'
+gem 'paperclip'
 
 gem 'papercrop', :path => ".."
 
@@ -14,7 +14,7 @@ gem "pry-debugger"
 gem "pry-doc"
 
 group :assets do
-  gem 'sass-rails',   '~> 3.2.3'
-  gem 'coffee-rails', '~> 3.2.1'
-  gem 'uglifier',     '>= 1.0.3'
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
 end

--- a/test_app/app/controllers/landscapes_controller.rb
+++ b/test_app/app/controllers/landscapes_controller.rb
@@ -40,7 +40,7 @@ class LandscapesController < ApplicationController
   # POST /landscapes
   # POST /landscapes.json
   def create
-    @landscape = Landscape.new(params[:landscape])
+    @landscape = Landscape.new(landscape_params)
 
     respond_to do |format|
       if @landscape.save
@@ -59,7 +59,7 @@ class LandscapesController < ApplicationController
     @landscape = Landscape.find(params[:id])
 
     respond_to do |format|
-      if @landscape.update_attributes(params[:landscape])
+      if @landscape.update_attributes(landscape_params)
         format.html { redirect_to @landscape, notice: 'Landscape was successfully updated.' }
         format.json { head :no_content }
       else
@@ -88,4 +88,11 @@ class LandscapesController < ApplicationController
       format.json { head :no_content }
     end
   end
+
+private
+
+  def landscape_params
+    params.fetch(:landscape, {}).permit!
+  end
+
 end

--- a/test_app/app/models/landscape.rb
+++ b/test_app/app/models/landscape.rb
@@ -1,8 +1,9 @@
 class Landscape < ActiveRecord::Base
-  attr_protected
 
   has_attached_file  :picture, :styles => {:thumb => "40x30", :medium => "400x300"},
                                :path   => ":rails_root/public/assets/uploads/landscapes/:id_:style.:extension",
-                               :url    => "uploads/landscapes/:id_:style.:extension"
+                               :url    => "/assets/uploads/landscapes/:id_:style.:extension"
+  validates_attachment_content_type :picture, :content_type => /.*/
   crop_attached_file :picture, :aspect => "4:3"
+
 end

--- a/test_app/config/application.rb
+++ b/test_app/config/application.rb
@@ -45,16 +45,12 @@ module TestApp
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
+    config.i18n.enforce_available_locales = false
+
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
-
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = false
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/test_app/config/environments/development.rb
+++ b/test_app/config/environments/development.rb
@@ -6,9 +6,6 @@ TestApp::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -21,13 +18,6 @@ TestApp::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
-
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/test_app/config/environments/production.rb
+++ b/test_app/config/environments/production.rb
@@ -61,7 +61,4 @@ TestApp::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 end

--- a/test_app/config/environments/test.rb
+++ b/test_app/config/environments/test.rb
@@ -11,9 +11,6 @@ TestApp::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -28,9 +25,6 @@ TestApp::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr

--- a/test_app/config/initializers/secret_token.rb
+++ b/test_app/config/initializers/secret_token.rb
@@ -5,3 +5,4 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 TestApp::Application.config.secret_token = 'eae79e907953926607428fa84311c5ed657c8738ef011d82ebeebe1fee8b0bbe19deae58263814bd7bb14e4b97bbf204f92b95f4a7c6dc97aa36f91ccbec45ac'
+TestApp::Application.config.secret_key_base = 'ac9b40108243846e34bc37949346f5964c9291b8b62ae3e1abf819d83188cbdc2061c0ab8e5c8f1f707cbb5a89c20799af0ca68fde471717401fbfe7906f1bba'

--- a/test_app/db/schema.rb
+++ b/test_app/db/schema.rb
@@ -9,18 +9,18 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120814094634) do
+ActiveRecord::Schema.define(version: 20120814094634) do
 
-  create_table "landscapes", :force => true do |t|
+  create_table "landscapes", force: true do |t|
     t.string   "name"
     t.string   "picture_file_name"
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
-    t.datetime "created_at",           :null => false
-    t.datetime "updated_at",           :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/test_app/test/fixtures/landscapes.yml
+++ b/test_app/test/fixtures/landscapes.yml
@@ -1,0 +1,2 @@
+one:
+  name: One

--- a/test_app/test/functional/landscapes_controller_test.rb
+++ b/test_app/test/functional/landscapes_controller_test.rb
@@ -1,8 +1,10 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class LandscapesControllerTest < ActionController::TestCase
+
   setup do
     @landscape = landscapes(:one)
+    @landscape.update_attributes(picture: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/matterhorn.jpg", 'image/jpg'))
   end
 
   test "should get index" do
@@ -18,10 +20,10 @@ class LandscapesControllerTest < ActionController::TestCase
 
   test "should create landscape" do
     assert_difference('Landscape.count') do
-      post :create, landscape: { name: @landscape.name }
+      post :create, landscape: { name: @landscape.name, picture: Rack::Test::UploadedFile.new("#{Rails.root}/test/fixtures/matterhorn.jpg", 'image/jpg')}
     end
-
-    assert_redirected_to landscape_path(assigns(:landscape))
+    assert_response :success
+    assert_template :crop
   end
 
   test "should show landscape" do
@@ -35,8 +37,8 @@ class LandscapesControllerTest < ActionController::TestCase
   end
 
   test "should update landscape" do
-    put :update, id: @landscape, landscape: { name: @landscape.name }
-    assert_redirected_to landscape_path(assigns(:landscape))
+    put :update, id: @landscape, landscape: { name: 'Updated Name' }
+    assert_response :redirect
   end
 
   test "should destroy landscape" do

--- a/test_app/test/test_helper.rb
+++ b/test_app/test/test_helper.rb
@@ -3,11 +3,15 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
+
+  include ActionDispatch::TestProcess
+
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
   fixtures :all
+  fixture_path = "#{::Rails.root}/test/fixtures"
 
   # Add more helper methods to be used by all tests here...
 end

--- a/test_app/test/unit/landscape_test.rb
+++ b/test_app/test/unit/landscape_test.rb
@@ -1,7 +1,11 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class LandscapeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  test 'Fixture is valid' do
+    Landscape.all.each do |landscape|
+      assert landscape.valid?
+    end
+  end
+
 end


### PR DESCRIPTION
Howdy,

Using this on a new project and wanted to use the latest version of Paperclip (4.1). There were some issues that I believe I've resolved. In particular, the requirement that all models with attachments validate the content type.

In truth, most of the issues I had to fix were related to tests. The Paperclip API has changed some and adjustments needed to be made.

I've also made the ImageMagick test comparisons a little more forgiving. All of the comparison tests were failing for me due to a 0.004 percent difference. I chalked this up to different versions of ImageMagick doing cropping a little differently and am now rounding to two decimal places. It will still fail if the crops are done wrong, but very subtile differences between ImageMagick versions should no longer cause tests to fail.

Let me know if you need anything else done. Looking forward to getting this PR merged so I can stop using my own fork.

Keep well,
Emerson
