### PR TITLE
Added ability to set minimum and maximum crop size

### DIFF
--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -10,6 +10,8 @@
       var width      = $(this).width();
       var min_size   = $("input#" + attachment + "_min_size").val().split('x');
       var max_size   = $("input#" + attachment + "_max_size").val().split('x');
+      var original_w = $("input[id$='_" + attachment + "_original_w']").val();
+      var original_h = $("input[id$='_" + attachment + "_original_h']").val();
 
       update_crop = function(coords) {
         var preview_width, rx, ry;
@@ -21,8 +23,8 @@
           ry = preview_width / coords.h;
 
           $("img#" + attachment + "_crop_preview").css({
-            width      : Math.round(rx * $("input[id$='_" + attachment + "_original_w']").val()) + "px",
-            height     : Math.round((ry * $("input[id$='_" + attachment + "_original_h']").val()) / aspect) + "px",
+            width      : Math.round(rx * original_w) + "px",
+            height     : Math.round((ry * original_h) / aspect) + "px",
             marginLeft : "-" + Math.round(rx * coords.x) + "px",
             marginTop  : "-" + Math.round((ry * coords.y) / aspect) + "px"
           });
@@ -37,7 +39,7 @@
       $(this).find("img").Jcrop({
         onChange    : update_crop,
         onSelect    : update_crop,
-        setSelect   : [0, 0, 250, 250],
+        setSelect   : [0, 0, original_w, 250],
         aspectRatio : aspect,
         minSize     : min_size,
         maxSize     : max_size,

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -8,6 +8,8 @@
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
       var width      = $(this).width();
+      var min_size   = $("input#" + attachment + "_min_size").val().split('x');
+      var max_size   = $("input#" + attachment + "_max_size").val().split('x');
 
       update_crop = function(coords) {
         var preview_width, rx, ry;
@@ -37,6 +39,8 @@
         onSelect    : update_crop,
         setSelect   : [0, 0, 250, 250],
         aspectRatio : aspect,
+        minSize     : min_size,
+        maxSize     : max_size,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {
         jcrop_api = this;

--- a/lib/papercrop/helpers.rb
+++ b/lib/papercrop/helpers.rb
@@ -47,7 +47,7 @@ module Papercrop
         box << self.hidden_field(:"#{attachment}_original_h", :value => original_height)
         box << self.hidden_field(:"#{attachment}_box_w",      :value => box_width)
 
-        for attribute in [:crop_x, :crop_y, :crop_w, :crop_h, :aspect] do
+        for attribute in [:crop_x, :crop_y, :crop_w, :crop_h, :aspect, :min_size, :max_size] do
           box << self.hidden_field(:"#{attachment}_#{attribute}", :id => "#{attachment}_#{attribute}")
         end
 

--- a/lib/papercrop/model_extension.rb
+++ b/lib/papercrop/model_extension.rb
@@ -14,7 +14,7 @@ module Papercrop
       # @param attachment_name [Symbol] Name of the desired attachment to crop
       # @param opts [Hash]
       def crop_attached_file(attachment_name, opts = {})
-        [:crop_x, :crop_y, :crop_w, :crop_h, :original_w, :original_h, :box_w, :aspect, :cropped_geometries].each do |a|
+        [:crop_x, :crop_y, :crop_w, :crop_h, :original_w, :original_h, :box_w, :aspect, :min_size, :max_size, :cropped_geometries].each do |a|
           attr_accessor :"#{attachment_name}_#{a}"
         end
 
@@ -30,8 +30,16 @@ module Papercrop
           opts[:aspect].first.to_f / opts[:aspect].last.to_f
         end
 
+        send :define_method, :"#{attachment_name}_min_size" do
+         opts[:min_size] =~ Papercrop::RegExp::SIZE ? opts[:min_size] : nil
+        end
+
+        send :define_method, :"#{attachment_name}_max_size" do
+         opts[:max_size] =~ Papercrop::RegExp::SIZE ? opts[:max_size] : nil
+        end
+
         if respond_to? :attachment_definitions
-          # for Paperclip <= 3.4 
+          # for Paperclip <= 3.4
           definitions = attachment_definitions
         else
           # for Paperclip >= 3.5

--- a/lib/papercrop/reg_exp.rb
+++ b/lib/papercrop/reg_exp.rb
@@ -2,5 +2,6 @@ module Papercrop
   module RegExp
     ASPECT   = /^([1-9]{1}\d*):([1-9]{1}\d*)$/
     CALLBACK = /reprocess_to_crop_(\S{1,})_attachment/
+    SIZE	 = /^(\d+x\d+)/i
   end
 end


### PR DESCRIPTION
If we do not set a minimum crop size, users can crop down to any size, resulting in paperclip having to upscale the small cropped images thereby reducing quality.

Also, setting initial crop area to maximum possible width for improved user experience.

Shall write tests later.
