### PR TITLE
Embed Jcrop.gif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .rvmrc
+.ruby-version
+.ruby-gemset
 .sass-cache
 *.gem
 *.swp

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -11,19 +11,20 @@
       var original_w = $("input[id$='_" + attachment + "_original_w']").val();
       var original_h = $("input[id$='_" + attachment + "_original_h']").val();
       var preview_w  = $("#" + attachment + "_crop_preview_wrapper").width();
+      var preview_h  = $("#" + attachment + "_crop_preview_wrapper").height();
 
       update_crop = function(coords) {
         var rx, ry;
 
         if (preview) {
           rx = preview_w / coords.w;
-          ry = preview_w / coords.h;
+          ry = preview_h / coords.h;
 
           $("img#" + attachment + "_crop_preview").css({
             width      : Math.round(rx * original_w) + "px",
-            height     : Math.round((ry * original_h) / aspect) + "px",
+            height     : Math.round(ry * original_h) + "px",
             marginLeft : "-" + Math.round(rx * coords.x) + "px",
-            marginTop  : "-" + Math.round((ry * coords.y) / aspect) + "px"
+            marginTop  : "-" + Math.round(ry * coords.y) + "px"
           });
         }
 

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -12,6 +12,11 @@
       var preview_w  = $("#" + attachment + "_crop_preview_wrapper").width();
       var preview_h  = $("#" + attachment + "_crop_preview_wrapper").height();
 
+      var crop_x_input = $("#" + attachment + "_crop_x");
+      var crop_y_input = $("#" + attachment + "_crop_y");
+      var crop_w_input = $("#" + attachment + "_crop_w");
+      var crop_h_input = $("#" + attachment + "_crop_h");
+
       var update_crop = function(coords) {
         var rx, ry;
 
@@ -27,10 +32,10 @@
           });
         }
 
-        $("#" + attachment + "_crop_x").val(Math.round(coords.x));
-        $("#" + attachment + "_crop_y").val(Math.round(coords.y));
-        $("#" + attachment + "_crop_w").val(Math.round(coords.w));
-        $("#" + attachment + "_crop_h").val(Math.round(coords.h));
+        crop_x_input.val(Math.round(coords.x));
+        crop_y_input.val(Math.round(coords.y));
+        crop_w_input.val(Math.round(coords.w));
+        crop_h_input.val(Math.round(coords.h));
       };
 
       $(this).find("img").Jcrop({

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -38,10 +38,23 @@
         crop_h_input.val(Math.round(coords.h));
       };
 
+      // Find the starting select box: as big as possible following the aspect
+      // ratio, and centered in the image
+      var select, maxWidth, maxHeight;
+      if (original_w / original_h > aspect) {
+        // Height is the constraining dimension
+        maxWidth = original_h * aspect;
+        select = [(original_w - maxWidth) / 2, 0, maxWidth, original_h];
+      } else {
+        // Width is the constraining demension
+        maxHeight = original_w / aspect;
+        select = [0, (original_h - maxHeight) / 2, original_w, maxHeight];
+      }
+
       $(this).find("img").Jcrop({
         onChange    : update_crop,
         onSelect    : update_crop,
-        setSelect   : [0, 0, 250, 250],
+        setSelect   : select,
         aspectRatio : aspect,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -8,19 +8,20 @@
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
       var width      = $(this).width();
+      var original_w = $("input[id$='_" + attachment + "_original_w']").val();
+      var original_h = $("input[id$='_" + attachment + "_original_h']").val();
+      var preview_w  = $("#" + attachment + "_crop_preview_wrapper").width();
 
       update_crop = function(coords) {
-        var preview_width, rx, ry;
+        var rx, ry;
 
         if (preview) {
-          preview_width = $("#" + attachment + "_crop_preview_wrapper").width();
-
-          rx = preview_width / coords.w;
-          ry = preview_width / coords.h;
+          rx = preview_w / coords.w;
+          ry = preview_w / coords.h;
 
           $("img#" + attachment + "_crop_preview").css({
-            width      : Math.round(rx * $("input[id$='_" + attachment + "_original_w']").val()) + "px",
-            height     : Math.round((ry * $("input[id$='_" + attachment + "_original_h']").val()) / aspect) + "px",
+            width      : Math.round(rx * original_w) + "px",
+            height     : Math.round((ry * original_h) / aspect) + "px",
             marginLeft : "-" + Math.round(rx * coords.x) + "px",
             marginTop  : "-" + Math.round((ry * coords.y) / aspect) + "px"
           });

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -7,7 +7,6 @@
       var attachment = $(this).attr("id").replace("_cropbox", "");
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
-      var width      = $(this).width();
       var original_w = $("input[id$='_" + attachment + "_original_w']").val();
       var original_h = $("input[id$='_" + attachment + "_original_h']").val();
       var preview_w  = $("#" + attachment + "_crop_preview_wrapper").width();

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -13,7 +13,7 @@
       var preview_w  = $("#" + attachment + "_crop_preview_wrapper").width();
       var preview_h  = $("#" + attachment + "_crop_preview_wrapper").height();
 
-      update_crop = function(coords) {
+      var update_crop = function(coords) {
         var rx, ry;
 
         if (preview) {

--- a/vendor/assets/stylesheets/jquery.jcrop.css.scss
+++ b/vendor/assets/stylesheets/jquery.jcrop.css.scss
@@ -15,7 +15,7 @@
 }
 
 /* These styles define the border lines */
-.jcrop-vline,.jcrop-hline{background:#FFF url(Jcrop.gif) top left repeat;font-size:0;position:absolute;}
+.jcrop-vline,.jcrop-hline{background:#FFF asset_data_url("Jcrop.gif") top left repeat;font-size:0;position:absolute;}
 .jcrop-vline{height:100%;width:1px!important;}
 .jcrop-hline{height:1px!important;width:100%;}
 .jcrop-vline.right{right:0;}
@@ -27,7 +27,7 @@
 /* This style is used for invisible click targets */
 .jcrop-tracker
 {
-  height: 100%; 
+  height: 100%;
   width: 100%;
   -webkit-tap-highlight-color: transparent; /* "turn off" link highlight */
   -webkit-touch-callout: none;              /* disable callout, image save panel */


### PR DESCRIPTION
This builds off my previous pull request(#20), and embeds JCrop.gif directly into the CSS using asset pipeline.  

This was necessary because JCrop.gif wasn't being deployed with precompiled assets.  We could have either updated the CSS to use the asset path, and included the image in asset compilation, or simply embed the image.  Because this images is so small (.33k), embedding it was better.  
