### PR TITLE
Unlock the aspect ratio

### DIFF
--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -7,6 +7,7 @@
       var attachment = $(this).attr("id").replace("_cropbox", "");
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
+      var aspect_lock = $("input#" + attachment + "_aspect").data('lock') === 'true';
       var width      = $(this).width();
 
       update_crop = function(coords) {
@@ -36,7 +37,7 @@
         onChange    : update_crop,
         onSelect    : update_crop,
         setSelect   : [0, 0, 250, 250],
-        aspectRatio : aspect,
+        aspectRatio : aspect_lock === true ? aspect : undefined,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {
         jcrop_api = this;

--- a/lib/papercrop/helpers.rb
+++ b/lib/papercrop/helpers.rb
@@ -1,10 +1,10 @@
 module Papercrop
   module Helpers
-    
+
     # Form helper to render the cropping preview box of an attachment.
-    # Box width can be handled by setting the :width option. 
+    # Box width can be handled by setting the :width option.
     # Width is 100 by default. Height is calculated by the aspect ratio.
-    # 
+    #
     #   crop_preview :avatar
     #   crop_preview :avatar, :width => 150
     #
@@ -13,7 +13,7 @@ module Papercrop
     def crop_preview(attachment, opts = {})
       attachment = attachment.to_sym
       width      = opts[:width] || 100
-      height     = (width / self.object.send(:"#{attachment}_aspect")).round 
+      height     = (width / self.object.send(:"#{attachment}_aspect")).round
 
       if self.object.send(attachment).class == Paperclip::Attachment
         wrapper_options = {
@@ -34,6 +34,9 @@ module Papercrop
     #
     #   cropbox :avatar, :width => 650
     #
+    # You can unlock the aspect ratio used by Jcrop by setting :aspect_lock to false
+    #   cropbox :avatar, :width => 650, :aspect_lock => false
+    #
     # @param attachment [Symbol] attachment name
     # @param opts [Hash]
     def cropbox(attachment, opts = {})
@@ -41,15 +44,17 @@ module Papercrop
       original_width  = self.object.image_geometry(attachment, :original).width
       original_height = self.object.image_geometry(attachment, :original).height
       box_width       = opts[:width] || original_width
+      aspect_lock     = opts[:aspect_lock] ||= "true"
 
       if self.object.send(attachment).class == Paperclip::Attachment
         box  = self.hidden_field(:"#{attachment}_original_w", :value => original_width)
         box << self.hidden_field(:"#{attachment}_original_h", :value => original_height)
         box << self.hidden_field(:"#{attachment}_box_w",      :value => box_width)
 
-        for attribute in [:crop_x, :crop_y, :crop_w, :crop_h, :aspect] do
+        for attribute in [:crop_x, :crop_y, :crop_w, :crop_h] do
           box << self.hidden_field(:"#{attachment}_#{attribute}", :id => "#{attachment}_#{attribute}")
         end
+        box << self.hidden_field(:"#{attachment}_aspect", :id => "#{attachment}_aspect", :'data-lock' => aspect_lock)
 
         crop_image = @template.image_tag(self.object.send(attachment).url)
 

--- a/lib/papercrop/model_extension.rb
+++ b/lib/papercrop/model_extension.rb
@@ -7,7 +7,7 @@ module Papercrop
       #
       #   crop_attached_file :avatar
       #
-      # You can also define an aspect ratio for the crop and preview box through opts[:aspect]
+      # You can also define an initial aspect ratio for the crop and preview box through opts[:aspect]
       #
       #   crop_attached_file :avatar, :aspect => "4:3"
       #
@@ -31,7 +31,7 @@ module Papercrop
         end
 
         if respond_to? :attachment_definitions
-          # for Paperclip <= 3.4 
+          # for Paperclip <= 3.4
           definitions = attachment_definitions
         else
           # for Paperclip >= 3.5
@@ -50,7 +50,7 @@ module Papercrop
 
       # Asks if the attachment received a crop process
       # @param  attachment_name [Symbol]
-      # 
+      #
       # @return [Boolean]
       def cropping?(attachment_name)
         !self.send(:"#{attachment_name}_crop_x").blank? &&
@@ -121,7 +121,7 @@ end
 
 
 # Mongoid support
-if defined? Mongoid::Document 
+if defined? Mongoid::Document
   Mongoid::Document::ClassMethods.module_eval do
     include Papercrop::ModelExtension::ClassMethods
   end

--- a/spec/helpers/form_helpers_spec.rb
+++ b/spec/helpers/form_helpers_spec.rb
@@ -41,6 +41,14 @@ describe "Form Helpers" do
     assert_select @box.root, 'input#landscape_picture_box_w', :value => "400"
   end
 
+  it "builds the crop box with unlocked aspect flag" do
+    form_for @landscape do |f|
+      @box = f.cropbox(:picture, :width => 400, :aspect_lock => false)
+    end
+    @box = HTML::Document.new(@box)
+
+    assert_select @box.root, 'input#landscape_picture_box_aspect', :'data-lock' => "false"
+  end
 
   it "builds the preview box" do
     form_for @landscape do |f|


### PR DESCRIPTION
This meets the request in [#2](https://github.com/rsantamaria/papercrop/issues/2)

Papercrop was exactly what I was looking for except for the aspect lock.  This changes behavior slightly so that the aspect ratio specified in the model becomes the initial aspect ratio when the unlock option is passed to the helper.  I kept it locked by default so that anyone updating their gem wouldn't need to go fix code.  Simple enough to flip around if needed.