### PR TITLE
Adding initial width and height for cropping

### DIFF
--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -8,10 +8,10 @@
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
       var width      = $(this).width();
-      var crop_x     = $("input#" + attachment + "_initial_crop_x").val();
-      var crop_y     = $("input#" + attachment + "_initial_crop_y").val();
-      var crop_w     = $("input#" + attachment + "_initial_crop_w").val();
-      var crop_h     = $("input#" + attachment + "_initial_crop_h").val();
+      var crop_x     = parseInt($("input#" + attachment + "_initial_crop_x").val());
+      var crop_y     = parseInt($("input#" + attachment + "_initial_crop_y").val());
+      var crop_w     = parseInt($("input#" + attachment + "_initial_crop_w").val());
+      var crop_h     = parseInt($("input#" + attachment + "_initial_crop_h").val());
 
       if (aspect === 'false') {
         aspect = false
@@ -43,7 +43,7 @@
       $(this).find("img").Jcrop({
         onChange    : update_crop,
         onSelect    : update_crop,
-        setSelect   : [crop_x, crop_y, crop_w, crop_h],
+        setSelect   : [crop_x, crop_y, crop_x + crop_w, crop_y + crop_h],
         aspectRatio : aspect === false ? undefined : aspect,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {

--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -8,6 +8,10 @@
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
       var width      = $(this).width();
+      var crop_x     = $("input#" + attachment + "_initial_crop_x").val();
+      var crop_y     = $("input#" + attachment + "_initial_crop_y").val();
+      var crop_w     = $("input#" + attachment + "_initial_crop_w").val();
+      var crop_h     = $("input#" + attachment + "_initial_crop_h").val();
 
       if (aspect === 'false') {
         aspect = false
@@ -39,7 +43,7 @@
       $(this).find("img").Jcrop({
         onChange    : update_crop,
         onSelect    : update_crop,
-        setSelect   : [0, 0, 250, 250],
+        setSelect   : [crop_x, crop_y, crop_w, crop_h],
         aspectRatio : aspect === false ? undefined : aspect,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {

--- a/lib/papercrop/helpers.rb
+++ b/lib/papercrop/helpers.rb
@@ -40,7 +40,7 @@ module Papercrop
     #   cropbox :avatar, :width => 650
     #
     # You can override the aspect ratio used by Jcrop, and even unlock it by setting :aspect to a new value or false
-    # 
+    #
     #   cropbox :avatar, :width => 650, :aspect => false
     #
     # @param attachment [Symbol] attachment name
@@ -51,13 +51,20 @@ module Papercrop
       original_height = self.object.image_geometry(attachment, :original).height.to_i
       box_width       = opts.fetch :width,  original_width
       aspect          = opts.fetch :aspect, self.object.send(:"#{attachment}_aspect")
+      crop_x          = opts.fetch :crop_x, 0
+      crop_y          = opts.fetch :crop_y, 0
+      crop_w, crop_h  = calculate_dimensions(opts, crop_x, crop_y, original_width, original_height, aspect)
 
       if self.object.send(attachment).class == Paperclip::Attachment
         box  = self.hidden_field(:"#{attachment}_original_w", :value => original_width)
         box << self.hidden_field(:"#{attachment}_original_h", :value => original_height)
         box << self.hidden_field(:"#{attachment}_box_w",      :value => box_width)
         box << self.hidden_field(:"#{attachment}_aspect",     :value => aspect, :id => "#{attachment}_aspect")
-        
+        box << self.hidden_field(:"#{attachment}_initial_crop_x", :value => crop_x, :id => "#{attachment}_initial_crop_x")
+        box << self.hidden_field(:"#{attachment}_initial_crop_y", :value => crop_y, :id => "#{attachment}_initial_crop_y")
+        box << self.hidden_field(:"#{attachment}_initial_crop_w", :value => crop_w, :id => "#{attachment}_initial_crop_w")
+        box << self.hidden_field(:"#{attachment}_initial_crop_h", :value => crop_h, :id => "#{attachment}_initial_crop_h")
+
         for attribute in [:crop_x, :crop_y, :crop_w, :crop_h] do
           box << self.hidden_field(:"#{attachment}_#{attribute}", :id => "#{attachment}_#{attribute}")
         end
@@ -65,6 +72,32 @@ module Papercrop
         crop_image = @template.image_tag(self.object.send(attachment).url)
 
         box << @template.content_tag(:div, crop_image, :id => "#{attachment}_cropbox")
+      end
+    end
+
+    #
+    # calculates the width and height of the cropped image.
+    #
+    def calculate_dimensions(opts, crop_x, crop_y, original_width, original_height, aspect)
+      remaining_width = original_width - crop_x
+      remaining_height= original_height - crop_x
+      if aspect
+        if remaining_width / aspect < remaining_height
+          return [
+            opts.fetch(:crop_w, crop_x + remaining_width),
+            opts.fetch(:crop_h, crop_y + remaining_width / aspect)
+          ]
+        else
+          return [
+            opts.fetch(:crop_w, crop_x + remaining_height * aspect),
+            opts.fetch(:crop_h, crop_y + remaining_height)
+          ]
+        end
+      else
+        return [
+          opts.fetch(:crop_w, original_width),
+          opts.fetch(:crop_h, original_height)
+        ]
       end
     end
   end

--- a/test_apps/shared_rails/app/views/landscapes/_crop_form.html.erb
+++ b/test_apps/shared_rails/app/views/landscapes/_crop_form.html.erb
@@ -1,12 +1,12 @@
 <%= form_for(@landscape) do |f| %>
-  
+
   <div class="landscape-crop-preview">
     <% # Will show a preview box with width=100, height is calculated by the aspect ratio. see model Landscape %>
     <%= f.crop_preview :picture %>
   </div>
   <div class="landscape-crop-area">
     <% # Crop area. Mantains original image proportions. Crop area takes the aspect ratio  %>
-    <%= f.cropbox :picture, :width => 600 %>
+    <%= f.cropbox :picture, :width => 600, crop_x: 400, crop_w: 800, crop_h: 90 %>
   </div>
   <div class="clear"></div>
 


### PR DESCRIPTION
Added the option to specify the initial crop position and size. If the size is not specified, it will take the maximum size, taking aspect ratio into account.

`<%= f.cropbox :picture, :width => 600, crop_x: 400, crop_y: 0 %>`
`<%= f.cropbox :picture, :width => 600, crop_x: 400, crop_y: 0, crop_w: 520, crop_h: 90 %>`

I am still working on the specs. I ran the PR against test_apps/rails_4 and the PR is currently being used in a production system.

Does the PR fit the scope of papercrop? (eg: will the PR be merged once the tests are implemented?) Also, does it comply with coding style and should the readme be updated?
